### PR TITLE
Add devnet network e2e test

### DIFF
--- a/e2e/clients/juno/client.star
+++ b/e2e/clients/juno/client.star
@@ -1,39 +1,50 @@
 base = import_module("../common/base.star")
 
 def run(plan, name, participant):
-    image = participant.get("image", "nethermind/juno:latest")
+    image = participant.get("image", "nethermindeth/juno:p2p_all")
     is_feeder = participant.get("is_feeder", False)
+    network = participant.get("network", "")  # Changed default to empty string
     private_key = participant.get("private_key", "")
     http_port = participant.get("http_port", 6060)
     p2p_port = participant.get("p2p_port", 7777)
     peer_multiaddrs = participant.get("peer_multiaddrs", [])
 
     cmd = [
-        "--network", "sepolia",
-        "--db-path", "/var/lib/juno",
-        "--log-level", "info",
         "--http",
         "--http-port", str(http_port),
         "--http-host", "0.0.0.0",
-        "--p2p",
-        "--p2p-addr", "/ip4/0.0.0.0/tcp/" + str(p2p_port),
-        "--p2p-private-key", private_key
+        "--log-level", "debug",
+        "--db-path", "/var/lib/juno",
     ]
-    if is_feeder:
-        cmd.append("--p2p-feeder-node")
-    for peer_multiaddr in peer_multiaddrs:
-        cmd.extend(["--p2p-peers", peer_multiaddr])
+
+    # Add P2P args only if we're in P2P mode
+    if is_feeder or peer_multiaddrs:
+        cmd.extend([
+            "--p2p",
+            "--p2p-addr", "/ip4/0.0.0.0/tcp/" + str(p2p_port),
+            "--p2p-private-key", private_key
+        ])
+        
+        if network:
+            cmd.extend(["--network", network])
+        if is_feeder:
+            cmd.append("--p2p-feeder-node")
+        for peer_multiaddr in peer_multiaddrs:
+            cmd.extend(["--p2p-peers", peer_multiaddr])
     
     ports = {
         "rpc": PortSpec(
             number=http_port,
             transport_protocol="TCP",
             application_protocol="http",
-        ),
-        "p2p": PortSpec(
+        )
+    }
+
+    # Only add p2p port if we're actually using P2P features
+    if is_feeder or peer_multiaddrs:
+        ports["p2p"] = PortSpec(
             number=p2p_port,
             transport_protocol="TCP",
         )
-    }
 
     return base.run(plan, name, image, cmd, ports, participant)

--- a/e2e/clients/madara/client.star
+++ b/e2e/clients/madara/client.star
@@ -1,0 +1,27 @@
+base = import_module("../common/base.star")
+
+def run(plan, name, participant):
+    image = participant.get("image", "ghcr.io/madara-alliance/madara:latest")
+    rpc_port = participant.get("rpc_port", 9944)
+    gateway_port = participant.get("gateway_port", 8080)
+    
+    cmd = [
+        "--rpc-port", str(rpc_port),
+        "--rpc-external",
+        "--rpc-cors=*"
+    ]
+
+    ports = {
+        "rpc": PortSpec(
+            number=rpc_port,
+            transport_protocol="TCP",
+            application_protocol="http",
+        ),
+        "gateway": PortSpec(
+            number=gateway_port,
+            transport_protocol="TCP",
+            application_protocol="http",
+        )
+    }
+
+    return base.run(plan, name, image, cmd, ports, participant)

--- a/e2e/clients/participants.star
+++ b/e2e/clients/participants.star
@@ -1,11 +1,14 @@
 juno = import_module("./juno/client.star")
 pathfinder = import_module("./pathfinder/client.star")
+madara = import_module("./madara/client.star")
 
 def run_participant(plan, name, participant):
     if participant["type"] == "juno":
         return juno.run(plan, name, participant)
     elif participant["type"] == "pathfinder":
         return pathfinder.run(plan, name, participant)
+    elif participant["type"] == "madara":
+        return madara.run(plan, name, participant)
     else:
         fail("Unknown client type: " + participant["type"])
 

--- a/e2e/main.star
+++ b/e2e/main.star
@@ -1,17 +1,20 @@
-# Import individual test modules
-juno_from_juno = import_module("tests/sync/juno_from_juno.star")
-juno_from_pathfinder = import_module("tests/sync/juno_from_pathfinder.star")
-pathfinder_from_pathfinder = import_module("tests/sync/pathfinder_from_pathfinder.star")
-pathfinder_from_juno = import_module("tests/sync/pathfinder_from_juno.star")
+juno_from_juno = import_module("./tests/sync/juno_from_juno.star")
+juno_from_pathfinder = import_module("./tests/sync/juno_from_pathfinder.star")
+pathfinder_from_juno = import_module("./tests/sync/pathfinder_from_juno.star")
+pathfinder_from_pathfinder = import_module("./tests/sync/pathfinder_from_pathfinder.star")
+devnet_network = import_module("./tests/hive/devnet_network.star")
 
 def run_juno_from_juno_sync(plan):
-    juno_from_juno.run(plan)
+    return juno_from_juno.run(plan)
 
 def run_juno_from_pathfinder_sync(plan):
-    juno_from_pathfinder.run(plan)
-
-def run_pathfinder_from_pathfinder_sync(plan):
-    pathfinder_from_pathfinder.run(plan)
+    return juno_from_pathfinder.run(plan)
 
 def run_pathfinder_from_juno_sync(plan):
-    pathfinder_from_juno.run(plan)
+    return pathfinder_from_juno.run(plan)
+
+def run_pathfinder_from_pathfinder_sync(plan):
+    return pathfinder_from_pathfinder.run(plan)
+
+def run_devnet_network(plan):
+    return devnet_network.run(plan)

--- a/e2e/tests/hive/devnet_network.star
+++ b/e2e/tests/hive/devnet_network.star
@@ -1,0 +1,98 @@
+participants = import_module("../../clients/participants.star")
+
+# Network and node configuration
+CHAIN_ID = "SN_WOJO"
+BLOCK_TIME = "30s"
+L1_CHAIN_ID = "31337"
+JUNO_P2P_PORT = "7777"
+JUNO_API_PORT = "6060"
+MADARA_PORT = "8080"
+# Private key for Juno feeder node
+TEST_PRIVATE_KEY = "67f8eae550a5265238431d719c2b62163011ab2a3f2ebeee3bc8f3135e2e2500b9e2c2e9e4ebeea82cca787094d74ab6fcae8ec0367e866dc1130de89e37150b"
+# Peer ID that second Juno node will use to discover and connect to the feeder node
+TEST_PEER_ID = "12D3KooWNKz9BJmyWVFUnod6SQYLG4dYZNhs3GrMpiot63Y1DLYS"
+
+def setup_madara_node(plan):
+    # Start Madara as a devnet sequencer with feeder gateway enabled
+    # This node will produce blocks that Juno nodes will sync
+    return participants.run_participant(plan, "madara-devnet", {
+        "type": "madara",
+        "extra_args": [
+            "--devnet",
+            "--override-devnet-chain-id",
+            "--chain-config-override=chain_id={},block_time={}".format(CHAIN_ID, BLOCK_TIME),
+            "--feeder-gateway-enable",
+            "--gateway-external"
+        ]
+    })
+
+def setup_juno_feeder_node(plan, madara_node):
+    # Start first Juno node that syncs directly from Madara's feeder gateway
+    # This node will propagate blocks to other Juno nodes via P2P
+    madara_url = "http://{}:{}".format(madara_node.ip_address, MADARA_PORT)
+    return participants.run_participant(plan, "juno-p2p-feeder-node", {
+        "type": "juno",
+        "is_feeder": True,
+        "private_key": TEST_PRIVATE_KEY,
+        "extra_args": [
+            "--cn-name", "devnet",
+            "--cn-feeder-url", "{}/feeder_gateway/".format(madara_url),
+            "--cn-gateway-url", "{}/gateway/".format(madara_url),
+            "--cn-l1-chain-id", L1_CHAIN_ID,
+            "--cn-l2-chain-id", CHAIN_ID,
+            "--cn-core-contract-address", "0x0000000000000000000000000000000000000000",
+            "--cn-unverifiable-range=0,0"
+        ]
+    })
+
+def setup_tester_service(plan):
+    # Setup service that will verify block synchronization on Juno nodes
+    return plan.add_service(
+        "devnet-tester",
+        config=ServiceConfig(
+            image=ImageBuildSpec(
+                image_name="sync-test",
+                build_context_dir="./../../tester",
+            ),
+        )
+    )
+
+def run_sync_test(plan, tester_image, node_ip, message=""):
+    # Verify that a Juno node has properly synced blocks
+    if message:
+        plan.print(message)
+    plan.exec(tester_image.name, ExecRecipe(
+        ["node", "index.mjs", "http://{}:{}".format(node_ip, JUNO_API_PORT), "10", "0"]
+    ))
+
+def setup_juno_peer_node(plan, feeder_node):
+    # Start second Juno node that syncs blocks via P2P from the feeder node
+    # This node doesn't connect to Madara directly
+    return participants.run_participant(plan, "juno-peer-node", {
+        "type": "juno",
+        "peer_multiaddrs": ["/ip4/{}/tcp/{}/p2p/{}".format(
+            feeder_node.ip_address, 
+            JUNO_P2P_PORT, 
+            TEST_PEER_ID
+        )]
+    })
+
+def run(plan):
+    # Test flow:
+    # 1. Start Madara sequencer with feeder gateway
+    madara_node = setup_madara_node(plan)
+    
+    # 2. Start first Juno node that syncs from Madara and shares blocks via P2P
+    juno_feeder_node = setup_juno_feeder_node(plan, madara_node)
+    tester_image = setup_tester_service(plan)
+
+    # 3. Verify first Juno node is syncing from Madara
+    run_sync_test(plan, tester_image, juno_feeder_node.ip_address, 
+                  "Waiting for juno feeder p2p to sync...")
+
+    # 4. Start second Juno node that syncs via P2P and verify its synchronization
+    peer_node = setup_juno_peer_node(plan, juno_feeder_node)
+    run_sync_test(plan, tester_image, peer_node.ip_address, 
+                  "Starting the peer sync test...")
+
+    plan.print("Devnet network test completed successfully")

--- a/e2e/tests/sync/juno_from_juno.star
+++ b/e2e/tests/sync/juno_from_juno.star
@@ -7,15 +7,17 @@ def run(plan):
         "is_feeder": True,
         "private_key": "67f8eae550a5265238431d719c2b62163011ab2a3f2ebeee3bc8f3135e2e2500b9e2c2e9e4ebeea82cca787094d74ab6fcae8ec0367e866dc1130de89e37150b",
         "http_port": 6060,
+        "network": "sepolia"
     })
 
     # Run the juno peer node with the feeder node as a peer
     peer_node = participants.run_participant(plan, "juno-peer", {
-        "type": "juno",
+        "type": "juno",   
         "is_feeder": False,
         "private_key": "a5a938ae6f012390fd68a10d3dd91038334fe5f0ed1c96753a3ee7bf0e8f1314e39307aea916c94e2d07e616fa20e315f4625c4f1e598ba2cc589410cc9c5cda",
         "http_port": 6061,
-        "peer_multiaddrs": ["/ip4/" + feeder_node.ip_address + "/tcp/7777/p2p/12D3KooWNKz9BJmyWVFUnod6SQYLG4dYZNhs3GrMpiot63Y1DLYS"]
+        "peer_multiaddrs": ["/ip4/" + feeder_node.ip_address + "/tcp/7777/p2p/12D3KooWNKz9BJmyWVFUnod6SQYLG4dYZNhs3GrMpiot63Y1DLYS"],
+        "network": "sepolia",
     })
 
     tester_image = plan.add_service(

--- a/e2e/tests/sync/juno_from_pathfinder.star
+++ b/e2e/tests/sync/juno_from_pathfinder.star
@@ -14,7 +14,8 @@ def run(plan):
         "is_feeder": False,
         "private_key": "a5a938ae6f012390fd68a10d3dd91038334fe5f0ed1c96753a3ee7bf0e8f1314e39307aea916c94e2d07e616fa20e315f4625c4f1e598ba2cc589410cc9c5cda",
         "http_port": 6061,
-        "peer_multiaddrs": ["/ip4/" + feeder_node.ip_address + "/tcp/20002/p2p/12D3KooWFY6SaqJkRxJDepwvBi4Rw36iMUGZrejW69qkjYQQ2ydQ"]
+        "peer_multiaddrs": ["/ip4/" + feeder_node.ip_address + "/tcp/20002/p2p/12D3KooWFY6SaqJkRxJDepwvBi4Rw36iMUGZrejW69qkjYQQ2ydQ"],
+        "network": "sepolia",
     })
 
     tester_image = plan.add_service(

--- a/e2e/tests/sync/pathfinder_from_juno.star
+++ b/e2e/tests/sync/pathfinder_from_juno.star
@@ -7,6 +7,7 @@ def run(plan):
         "is_feeder": True,
         "private_key": "67f8eae550a5265238431d719c2b62163011ab2a3f2ebeee3bc8f3135e2e2500b9e2c2e9e4ebeea82cca787094d74ab6fcae8ec0367e866dc1130de89e37150b",
         "http_port": 6060,
+        "network": "sepolia"
     })
 
     # Run the Pathfinder node with the juno node as a peer


### PR DESCRIPTION
Add end-to-end test that verifies block propagation in a devnet setup:
- Madara node running as devnet sequencer with feeder gateway
- Juno feeder node syncing from Madara and acting as P2P seed
- Juno peer node syncing via P2P from feeder node

Test validates:
1. Block propagation from Madara to Juno via feeder gateway
2. P2P block propagation between Juno nodes