### PR TITLE
Add required flag

### DIFF
--- a/e2e/clients/juno/client.star
+++ b/e2e/clients/juno/client.star
@@ -15,6 +15,7 @@ def run(plan, name, participant):
         "--http-host", "0.0.0.0",
         "--log-level", "debug",
         "--db-path", "/var/lib/juno",
+        "--disable-l1-verification"
     ]
 
     # Add P2P args only if we're in P2P mode


### PR DESCRIPTION
Since https://github.com/NethermindEth/juno/pull/2249,
it's now required to either pass the --eth-node flag or
--disable-l1-verification